### PR TITLE
Fix issue #2: Fix typo in health endpoint

### DIFF
--- a/src/sentinel_system/routers/health.py
+++ b/src/sentinel_system/routers/health.py
@@ -34,7 +34,7 @@ async def health_check():
     - Git configuration
     """
     checks = {}
-    overall_status = "heathy"
+    overall_status = "healthy"
     
     # Check GitHub token
     try:


### PR DESCRIPTION
Resolves #2

## Implementation Summary

[dotenv@16.6.0] injecting env (12) from .env
[dotenv@16.6.0] injecting env (12) from .env
The typo in the `health` endpoint's print message has been corrected. The string "heathy" was changed to "healthy" in the `overall_status` variable within the `health_check` function in `/Users/dhrupadsah/personal/sentinel-system/src/sentinel_system/routers/health.py`.

## Changes Made
- Implemented solution as approved in issue #2
- All changes are focused on resolving the specific issue

**Auto-generated by Sentinel System**
