### PR TITLE
Fix issue #3: Fix typo in health endpoint

### DIFF
--- a/src/sentinel_system/routers/health.py
+++ b/src/sentinel_system/routers/health.py
@@ -34,7 +34,7 @@ async def health_check():
     - Git configuration
     """
     checks = {}
-    overall_status = "heathy"
+    overall_status = "healthy"
     
     # Check GitHub token
     try:


### PR DESCRIPTION
Resolves #3

## Implementation Summary

[dotenv@16.6.0] injecting env (12) from .env
[dotenv@16.6.0] injecting env (12) from .env
I have fixed the typo in the health endpoint. The `overall_status` in `src/sentinel_system/routers/health.py` has been changed from "heathy" to "healthy".

## Changes Made
- Implemented solution as approved in issue #3
- All changes are focused on resolving the specific issue

**Auto-generated by Sentinel System**
